### PR TITLE
Add initial support for pushing to remote head

### DIFF
--- a/lib/App/MintTag/BuildStep.pm
+++ b/lib/App/MintTag/BuildStep.pm
@@ -41,6 +41,12 @@ has push_tag_to => (
   is => 'ro',
 );
 
+# Hashref: { remote => $remote, branch => 'branchname', force => $bool }
+has push_spec => (
+  is => 'ro',
+  predicate => 'has_push_spec',
+);
+
 # whether we should rebase before merging
 has rebase => (
   is => 'ro',

--- a/lib/App/MintTag/Config.pm
+++ b/lib/App/MintTag/Config.pm
@@ -166,7 +166,17 @@ sub _assemble_steps ($class, $step_config, $remotes) {
     my $tag_remote;
     if (my $tag_remote_name = delete $step->{push_tag_to}) {
       $tag_remote = $remotes->{$tag_remote_name};
-      die "No matching remote found for $tag_remote!\n" unless $tag_remote;
+      die "No matching remote found for $tag_remote_name!\n" unless $tag_remote;
+    }
+
+    if (my $spec = $step->{push_spec}) {
+      die "push_spec must have 'remote' and 'branch' keys\n"
+        unless $spec->{remote} && $spec->{branch};
+
+      my $remote = $remotes->{ $spec->{remote} };
+      die "No matching remote found for $spec->{remote}!\n" unless $remote;
+
+      $spec->{remote} = $remote;  # replace with a real remote object
     }
 
     push @steps, App::MintTag::BuildStep->new({

--- a/lib/App/MintTag/Remote/GitLab.pm
+++ b/lib/App/MintTag/Remote/GitLab.pm
@@ -54,7 +54,7 @@ sub get_mrs_for_label ($self, $label, $trusted_org_name) {
 
   # TODO: import pagination logic from Github. -- michael, 2020-05-19
 
-  return [] unless @$mrs;
+  return unless @$mrs;
 
   my @sorted = sort { $a->{iid} <=> $b->{iid} } @$mrs;
   my @mrs;


### PR DESCRIPTION
That is: pushing the built project to a head and not as a tag.