### PR TITLE
Try creating parent directory before baling out

### DIFF
--- a/lib/App/MintTag.pm
+++ b/lib/App/MintTag.pm
@@ -141,6 +141,7 @@ sub ensure_initial_prep ($self) {
     die "local path $dir does not exist! (maybe you should set clone = true)\n"
       unless $self->config->should_clone;
 
+    $dir->parent->mkpath unless $dir->parent->is_dir;
     chdir $dir->parent or die "Couldn't chdir to $dir\'s parent!\n";
 
     $Logger->log(["cloning into $dir from %s", $self->upstream_base]);


### PR DESCRIPTION
Mostly a convenience thing.  

For example if the config path is /tmp/foo/bar then anyone using a tmpfs has to manually recreate /tmp/foo after every reboot because it bails out if it cant chdir into it.

