### PR TITLE
Add an option for tagging arbitrary shas

### DIFF
--- a/bin/mint-tag
+++ b/bin/mint-tag
@@ -18,12 +18,17 @@ use Getopt::Long::Descriptive;
 my ($opt, $usage) = describe_options(
   '%c %o',
   [ 'config|c=s', 'config file to use', { required => 1 } ],
+  [ 'sha=s',      'do not do any merging, just tag this sha' ],
   [ 'auto',       'do not run in interactive mode' ],
   [ 'verbose|v',  'turn on debug logging' ],
   [ 'help|h',     'show help and exit', { shortcircuit => 1 } ],
 );
 
 print($usage->text), exit if $opt->help;
+
+if ($opt->sha && $opt->auto) {
+  $usage->die({ pre_text => "error: --sha must be run in manual mode\n"});
+}
 
 local $Logger = $Logger;
 unless ($opt->auto) {
@@ -33,4 +38,11 @@ unless ($opt->auto) {
 
 $Logger->set_debug(1) if $opt->verbose;
 
-App::MintTag->from_config_file($opt->config)->mint_tag($opt->auto);
+my $minttag = App::MintTag->from_config_file($opt->config);
+
+if ($opt->sha) {
+  $minttag->tag_arbitrary_sha($opt->sha);
+  exit 0;
+}
+
+$minttag->mint_tag($opt->auto);

--- a/lib/App/MintTag/BuildStep.pm
+++ b/lib/App/MintTag/BuildStep.pm
@@ -63,7 +63,8 @@ sub BUILD ($self, $arg) {
 has _merge_requests => (
   is => 'ro',
   init_arg => undef,
-  writer => 'set_merge_requests'
+  default => sub { [] },
+  writer => 'set_merge_requests',
 );
 
 sub merge_requests { $_[0]->_merge_requests->@* }


### PR DESCRIPTION
More than once, I have seen some commentary in Slack that's like "oh, it
would be nice if mint-tag could let you include arbitrary merge requests
or commits in its merge process." Usually this comes up because someone
wants to make a hotfix to some already-released thing with a single
commit on top, and they don't want to mint a brand new tag (because
maybe the main branch had already moved on, or whatever).

I definitely don't want to do that, because that way lies madness:
mint-tag is *absolutely not* and will never be an alternative git CLI.
My response to this has always been "why do you want such a thing, when
git cherry-pick exists?"

But the one thing that _would_ actually be useful is to have the commit
automatically tagged and pushed according to your normal config file, so
that's what I've done here. You can now provide `--sha` in addition to
the config file; if you do, we bypass all the merging, approving, etc.
and just tag whatever you want using the correct tag format in the
config and pushing, if necessary. (This only works if there is exactly
one tag format in your config file.)

I think this is a small change, and provides a solution to the real
problem of "oops, I need to cherry-pick and release this one commit, but
don't want to figure out the correct tag format and where to push it."