### PR TITLE
conflict detector: try harder to find conflicts

### DIFF
--- a/lib/App/MintTag.pm
+++ b/lib/App/MintTag.pm
@@ -473,14 +473,8 @@ sub _find_conflict ($self, $known_bad, $all_mrs) {
 
     try {
       $Logger->log([ "merging %s to check for conflict", $mr->ident ]);
-
-      # NB: this prefix nonsense is because I have diff.noprefix true in my
-      # local gitconfig, which causes this command to fail cryptically.
-      my $patch = run_git(
-        'format-patch', '--src-prefix=a/', '--dst-prefix=b/', '--stdout', 'HEAD..' . $mr->sha
-      );
-
-      run_git('apply', '--check', { stdin => \$patch });
+      run_git('merge', '--no-ff', '-m' => $mr->as_commit_message, $mr->sha);
+      run_git('submodule', 'update');
     } catch {
       my $err = $_;
       chomp $err;


### PR DESCRIPTION
When I copied this bit from mint-tag's ancestor, I rewrote these merges
to use `git apply --check` rather than doing the merge. That caused the
error reporting to be wrong, in certain complex cases.

Imagine a situation like this:

- mr!1, touches foo.txt
- mr!2, touches bar.txt
- mr!3, touches foo.txt
- mr!4, touches bar.txt

Here, there are two potential conflicts (one between 1 and 3 in foo.txt,
the other between 2 and 4 in bar.txt). Say that in foo.txt, a 3-way
merge can resolve them, but in bar.txt, it cannot.

When mint-tag goes to merge this set of MRs, it first tries to do a
4-way octopus, which fails because of the conflict between 2 and 4 in
bar.txt. It then merges each MR in sequence, stopping when it is unable
to merge bar.txt with mr!4. Before this commit, it would then merge
mr!4, then run `git apply --check` with each patch for the others to
find the conflict. Often, this would report the wrong conflict (as being
between 1 and 3), because the patch would not apply, but would have with
--3way (or in a 3-way merge).  Adding --3way to the `git apply`
incantation would help with this, but then a sequential merge would
succeed when the octopus failed, which we definitely *don't* want
(because the resulting code is maybe not what was intended).

The fix here is just to do what the old code did (and the intermediate
step here already does), which is just to actually merge the things.
This seems to fix the bad case and doesn't seem to have any other
unintended side effects.