### PR TITLE
Assert that user is member of trusted org

### DIFF
--- a/lib/App/MintTag/Remote.pm
+++ b/lib/App/MintTag/Remote.pm
@@ -49,11 +49,14 @@ has clone_url => (
   builder => 'obtain_clone_url',
 );
 
-has trusted_org_memberships => (
+has _org_memberships => (
   is => 'ro',
   lazy => 1,
   default => sub { {} },
 );
+
+sub is_member_of_org    ($self, $name) { $self->_org_memberships->{$name}     }
+sub note_org_membership ($self, $name) { $self->_org_memberships->{$name} = 1 }
 
 sub http_get ($self, $url) {
   my $res = $self->ua->get($url);

--- a/lib/App/MintTag/Remote.pm
+++ b/lib/App/MintTag/Remote.pm
@@ -49,6 +49,12 @@ has clone_url => (
   builder => 'obtain_clone_url',
 );
 
+has trusted_org_memberships => (
+  is => 'ro',
+  lazy => 1,
+  default => sub { {} },
+);
+
 sub http_get ($self, $url) {
   my $res = $self->ua->get($url);
 

--- a/lib/App/MintTag/Remote/GitHub.pm
+++ b/lib/App/MintTag/Remote/GitHub.pm
@@ -141,7 +141,7 @@ sub usernames_for_org ($self, $name) {
 }
 
 sub assert_org_membership ($self, $name) {
-  return if $self->trusted_org_memberships->{$name};
+  return if $self->is_member_of_org($name);
 
   my $res = try {
     $self->http_get(sprintf("%s/user/memberships/orgs/%s",
@@ -155,7 +155,7 @@ sub assert_org_membership ($self, $name) {
   die "You don't seem to be a member of org '$name'; giving up."
     unless $res->{role} =~ /^(member|admin)$/;
 
-  $self->trusted_org_memberships->{$name} = 1;
+  $self->note_org_membership($name);
 }
 
 1;

--- a/lib/App/MintTag/Remote/GitHub.pm
+++ b/lib/App/MintTag/Remote/GitHub.pm
@@ -29,12 +29,6 @@ has ua => (
   },
 );
 
-has trusted_org_memberships => (
-  is => 'ro',
-  lazy => 1,
-  default => sub { {} },
-);
-
 sub uri_for ($self, $part, $query = {}) {
   my $uri = URI->new(sprintf(
     "%s/repos/%s%s",

--- a/lib/App/MintTag/Remote/GitLab.pm
+++ b/lib/App/MintTag/Remote/GitLab.pm
@@ -134,7 +134,7 @@ sub usernames_for_org ($self, $name) {
 }
 
 sub assert_org_membership ($self, $name) {
-  return if $self->trusted_org_memberships->{$name};
+  return if $self->is_member_of_org($name);
 
   # Grab our auth info, then check if we're in the trusted group.
   my $me_id = $self->my_user_id;
@@ -152,7 +152,7 @@ sub assert_org_membership ($self, $name) {
   die "You don't seem to be a member of org '$name'; giving up."
     unless $member->{access_level} >= 10;  # 10 == "guest"
 
-  $self->trusted_org_memberships->{$name} = 1;
+  $self->note_org_membership($name);
 }
 
 1;


### PR DESCRIPTION
We hired a new person, but neglected to add them to our org on GitHub.
Today, that person went to mint a tag, which didn't correctly include
all the right merge requests!

This happened via a confluence of things:

- If a build step has a `trusted_org_name`, MRs tagged with the right
  label, but by users who are not members of the trusted org, are
  ignored.
- GitHub's API to get organization members only shows public members.
  (Most of Fastmail's GitHub members are private.)
- The person running mint-tag was not, themselves, a member of the
  Fastmail org on GitHub.

This meant that when they went to go mint the tag, mint-tag said "Great,
let's check the trusted members," and only saw the _public_ members of
the org. Many of the tagged MRs were made by private members, so they
simply weren't included in the merge (and since this is the first time
they'd run mint-tag, the log lines saying some MRs were skipped weren't
obvious.)

The solution is straightforward. GitHub provides an API to check
org membership using the provided token's auth, so before we start
merging, we assert that the user running the program is in fact a member
of the trusted org. If not, we bail out immediately, rather than
deploying a subtly wrong tag!

We should do a similar change for GitLab, but GitLab doesn't provide the
same API so it requires slightly more config. (Plus, internal
organization of Fastmail mean we are less likely to be bitten by the
GitLab side of things, so its commit will come later.)