### PR TITLE
Semilinear merges

### DIFF
--- a/lib/App/MintTag.pm
+++ b/lib/App/MintTag.pm
@@ -238,19 +238,22 @@ sub merge_strategy_semilinear ($self, $step) {
     try {
       $mr->rebase($new_base);
 
+      my $msg = $mr->as_multiline_commit_message($self->target_branch_name);
+
       run_git('checkout', $self->target_branch_name);;
-      run_git('merge', '--no-ff', '-m' => $mr->as_commit_message, $mr->sha);
+      run_git('merge', '--no-ff', '-m' => $msg, $mr->sha);
       run_git('submodule', 'update');
 
       $Logger->log(["rebased and merged %s into %s", $mr->ident, $self->target_branch_name ]);
     } catch {
       my $e = $_;
       $Logger->log_fatal([
-        "Error rebasing %s!%s (%s) onto HEAD (%s); bailing out!",
+        "Error rebasing %s!%s (%s) onto HEAD (%s); bailing out! Error: %s",
         $mr->remote_name,
         $mr->number,
         $mr->sha,
         substr($new_base, 0, 8),
+        $e,
       ])
     };
   }

--- a/lib/App/MintTag/BuildStep.pm
+++ b/lib/App/MintTag/BuildStep.pm
@@ -53,6 +53,11 @@ has rebase => (
   default => 0,
 );
 
+has use_semilinear_merge => (
+  is => 'ro',
+  default => 0,
+);
+
 sub BUILD ($self, $arg) {
   if ($self->push_tag_to && ! $self->tag_prefix) {
     my $name = $self->name;

--- a/lib/App/MintTag/BuildStep.pm
+++ b/lib/App/MintTag/BuildStep.pm
@@ -58,6 +58,11 @@ has use_semilinear_merge => (
   default => 0,
 );
 
+has force_push_rebased_branches => (
+  is => 'ro',
+  default => 0,
+);
+
 sub BUILD ($self, $arg) {
   if ($self->push_tag_to && ! $self->tag_prefix) {
     my $name = $self->name;

--- a/lib/App/MintTag/MergeRequest.pm
+++ b/lib/App/MintTag/MergeRequest.pm
@@ -15,41 +15,15 @@ has remote => (
   },
 );
 
-has number => (
-  is => 'ro',
-  required => 1,
-);
-
-has author => (
-  is => 'ro',
-  required => 1,
-);
-
-has title => (
-  is => 'ro',
-  required => 1,
-);
-
-# Maybe: not required, and maybe we want something different, but will wait
-# and see. All this is really here to do is so that eventually we can say
-# git fetch $some_string that will fetch and set FETCH_HEAD
-
-has fetch_spec => (
-  is => 'ro',
-  required => 1,
-);
-
-has refname => (
-  is => 'ro',
-  required => 1,
-);
-
-has branch_name => (
-  is => 'ro',
-  required => 1,
-);
-
-has web_url => (
+has [qw(
+  author
+  branch_name
+  fetch_spec
+  number
+  ref_name
+  title
+  web_url
+)] => (
   is => 'ro',
   required => 1,
 );
@@ -91,7 +65,7 @@ has state => (
 );
 
 sub as_fetch_args ($self) {
-  return ($self->fetch_spec, $self->refname);
+  return ($self->fetch_spec, $self->ref_name);
 }
 
 sub oneline_desc ($self) {

--- a/lib/App/MintTag/MergeRequest.pm
+++ b/lib/App/MintTag/MergeRequest.pm
@@ -44,6 +44,16 @@ has refname => (
   required => 1,
 );
 
+has branch_name => (
+  is => 'ro',
+  required => 1,
+);
+
+has web_url => (
+  is => 'ro',
+  required => 1,
+);
+
 has sha => (
   is => 'ro',
   required => 1,
@@ -96,6 +106,15 @@ sub oneline_desc ($self) {
 # Silly, but I've now typed this like 8 times, so.
 sub as_commit_message ($self) {
   return "Merge " . $self->oneline_desc;
+}
+
+sub as_multiline_commit_message ($self, $target_branch) {
+  return sprintf(
+    "Merge branch '%s' into '%s'\n\nSee %s\n",
+    $self->branch_name,
+    $target_branch,
+    $self->web_url,
+  );
 }
 
 sub rebase ($self, $new_base) {

--- a/lib/App/MintTag/MergeRequest.pm
+++ b/lib/App/MintTag/MergeRequest.pm
@@ -64,6 +64,11 @@ has state => (
   is => 'ro',
 );
 
+has has_been_rebased_locally => (
+  is => 'rw',
+  default => 0,
+);
+
 sub as_fetch_args ($self) {
   return ($self->fetch_spec, $self->ref_name);
 }
@@ -101,6 +106,8 @@ sub rebase ($self, $new_base) {
 
   my $patch_id = compute_patch_id($new_base, $new_sha);
   $self->set_patch_id($patch_id);
+
+  $self->has_been_rebased_locally(1);
 
   return 1;
 }

--- a/lib/App/MintTag/Remote/GitHub.pm
+++ b/lib/App/MintTag/Remote/GitHub.pm
@@ -109,15 +109,15 @@ sub _mr_from_raw ($self, $raw) {
   my $number = $raw->{number};
 
   return App::MintTag::MergeRequest->new({
-    remote     => $self,
-    number     => $number,
-    author     => $raw->{user}->{login},
-    title      => $raw->{title},
-    fetch_spec => $self->name,
-    refname    => "pull/$number/head",
-    sha        => $raw->{head}->{sha},
-    state      => $raw->{state},
-    web_url    => $raw->{html_url},
+    remote      => $self,
+    number      => $number,
+    author      => $raw->{user}->{login},
+    title       => $raw->{title},
+    fetch_spec  => $self->name,
+    ref_name    => "pull/$number/head",
+    sha         => $raw->{head}->{sha},
+    state       => $raw->{state},
+    web_url     => $raw->{html_url},
     branch_name => $raw->{head}->{ref},
   });
 }

--- a/lib/App/MintTag/Remote/GitHub.pm
+++ b/lib/App/MintTag/Remote/GitHub.pm
@@ -117,6 +117,8 @@ sub _mr_from_raw ($self, $raw) {
     refname    => "pull/$number/head",
     sha        => $raw->{head}->{sha},
     state      => $raw->{state},
+    web_url    => $raw->{html_url},
+    branch_name => $raw->{head}->{ref},
   });
 }
 

--- a/lib/App/MintTag/Remote/GitLab.pm
+++ b/lib/App/MintTag/Remote/GitLab.pm
@@ -108,6 +108,8 @@ sub _mr_from_raw ($self, $raw) {
     refname    => "merge-requests/$number/head",
     sha        => $raw->{sha},
     state      => $raw->{state},
+    web_url    => $raw->{web_url},
+    branch_name => $raw->{source_branch},
   });
 }
 

--- a/lib/App/MintTag/Remote/GitLab.pm
+++ b/lib/App/MintTag/Remote/GitLab.pm
@@ -100,15 +100,15 @@ sub _mr_from_raw ($self, $raw) {
   my $number = $raw->{iid};
 
   return App::MintTag::MergeRequest->new({
-    remote     => $self,
-    number     => $number,
-    title      => $raw->{title},
-    author     => $raw->{author}->{username},
-    fetch_spec => $self->name,
-    refname    => "merge-requests/$number/head",
-    sha        => $raw->{sha},
-    state      => $raw->{state},
-    web_url    => $raw->{web_url},
+    remote      => $self,
+    number      => $number,
+    title       => $raw->{title},
+    author      => $raw->{author}->{username},
+    fetch_spec  => $self->name,
+    ref_name    => "merge-requests/$number/head",
+    sha         => $raw->{sha},
+    state       => $raw->{state},
+    web_url     => $raw->{web_url},
     branch_name => $raw->{source_branch},
   });
 }


### PR DESCRIPTION
This gives the build step a new config option, use_semilinear_merge. If
that's set, for every MR, we'll rebase it and create a merge commit as
we go. This is different than the current `rebase` option, which for N
MRs to be merged into main, rebases all N on main and then does a single
octopus merge; semilinear merge will create N merge commits.

There's a minor bit of refactoring here, because I realized we can just
set the author/committer env vars in one place rather than doing it
in multiple places. (Setting GIT_AUTHOR_EMAIL is safe to do because git
will not rewrite commit authors unless you ask it to, which we do not.)