### PR TITLE
Fix behavior of force-push for forks

### DIFF
--- a/lib/App/MintTag.pm
+++ b/lib/App/MintTag.pm
@@ -378,11 +378,11 @@ sub maybe_push ($self, $step, $tagname = undef) {
 
       try {
         $Logger->log(["force-pushing branch to %s/%s",
-          $mr->remote_name,
+          $mr->force_push_url,
           $mr->branch_name,
         ]);
 
-        run_git('push', '--force-with-lease', $mr->remote_name, $push_spec);
+        run_git('push', '--force', $mr->force_push_url, $push_spec);
       } catch {
         my $err = $_;
 

--- a/lib/App/MintTag/MergeRequest.pm
+++ b/lib/App/MintTag/MergeRequest.pm
@@ -21,6 +21,7 @@ has [qw(
   fetch_spec
   number
   ref_name
+  force_push_url
   title
   web_url
 )] => (

--- a/lib/App/MintTag/Remote/GitHub.pm
+++ b/lib/App/MintTag/Remote/GitHub.pm
@@ -124,6 +124,7 @@ sub _mr_from_raw ($self, $raw) {
     state       => $raw->{state},
     web_url     => $raw->{html_url},
     branch_name => $raw->{head}->{ref},
+    force_push_url => $raw->{head}->{repo}->{ssh_url},
   });
 }
 

--- a/lib/App/MintTag/Remote/GitLab.pm
+++ b/lib/App/MintTag/Remote/GitLab.pm
@@ -104,6 +104,13 @@ sub get_mr ($self, $number) {
 sub _mr_from_raw ($self, $raw) {
   my $number = $raw->{iid};
 
+  # This is so jank, but I want to save an HTTP request
+  my $reference = $raw->{references}{full};   # michael/mint-tag!42
+  my $ssh_url = $self->obtain_clone_url;      # git@gitlab.com:fastmail/mint-tag.git
+  my ($ssh_base)  = split /:/, $ssh_url;
+  my ($push_spec) = split /!/, $reference;
+  my $force_push_url = "$ssh_base:$push_spec.git";
+
   return App::MintTag::MergeRequest->new({
     remote      => $self,
     number      => $number,
@@ -115,6 +122,7 @@ sub _mr_from_raw ($self, $raw) {
     state       => $raw->{state},
     web_url     => $raw->{web_url},
     branch_name => $raw->{source_branch},
+    force_push_url => $force_push_url,
   });
 }
 


### PR DESCRIPTION
The change introduced in 3a339676 does not work for the normal
GitHub/GitLab case, where changes are introduced in a fork and merged
into the golden repository. This commit fixes that by adding a new
property on merge request objects, `force_push_url`, and populating it
appropriately.

Imagine we're working on the repo `fastmail/mint-tag`, and I introduce a
change on `michael/mint-tag`, in MR 42. Before, we'd do this:

- http fetch MR 42
- git fetch it, using the magic ref generated for merge requests
- do our rebase and merge
- attempt to force push to fastmail/my-feature-branch

This last step was failing, because my-feature-branch never existed on
fastmail/mint-tag; it only exists on michael/mint-tag! Now, we'll
correctly push to michael/mint-tag, using the ssh URL we populate during
the http fetch.