### PR TITLE
Wait for remote to notice when pushing rebased MRs

### DIFF
--- a/lib/App/MintTag.pm
+++ b/lib/App/MintTag.pm
@@ -383,6 +383,8 @@ sub maybe_push ($self, $step, $tagname = undef) {
         ]);
 
         run_git('push', '--force', $mr->force_push_url, $push_spec);
+
+        $mr->wait_until_remote_head_is_correct;
       } catch {
         my $err = $_;
 


### PR DESCRIPTION
When you force-push to an MR (in GitLab, at least), there is often a lag
between the time you do so (with git) and the the time GitLab takes to
notice it (via http). That means that if you rebase an MR, force-push to
the branch, then immediately merge it and push to the golden repo,
GitLab *won't notice* and thus won't mark the MR as merged, but instead
it stays open and says "no changes," which sucks.

This commit also sucks, which is just "sleep in a loop until the remote
is up to date".