### PR TITLE
Implement HTTPS cloning

### DIFF
--- a/lib/App/MintTag/Config.pm
+++ b/lib/App/MintTag/Config.pm
@@ -124,7 +124,9 @@ has _remotes_by_url => (
   default => sub ($self) {
     # This is potentially lossy, if you have the same remote with more than
     # one name. I think that's fine, for the purposes we need it for.
-    return +{ map {; $_->clone_url => $_ } $self->all_remotes };
+    my $remote_by_https_url = +{ map {; $_->obtain_https_clone_url() => $_ } $self->all_remotes };
+    my $remote_by_ssh_url = +{ map {; $_->obtain_ssh_clone_url() => $_ } $self->all_remotes };
+    return { %$remote_by_https_url, %$remote_by_ssh_url } ;
   }
 );
 

--- a/lib/App/MintTag/Remote.pm
+++ b/lib/App/MintTag/Remote.pm
@@ -9,7 +9,8 @@ use JSON::MaybeXS qw(decode_json is_bool);
 
 use App::MintTag::Logger '$Logger';
 
-requires 'obtain_clone_url';    # get_clone_url was confusing...
+requires 'obtain_https_clone_url';    # get_clone_url was confusing...
+requires 'obtain_ssh_clone_url';
 requires 'get_mrs_for_label';
 requires 'get_mr';
 requires 'ua';
@@ -50,7 +51,14 @@ has repo => (
 has clone_url => (
   is => 'ro',
   lazy => 1,
-  builder => 'obtain_clone_url',
+  builder => sub ($self) {
+      return $self->do_clone_via_https ? $self->obtain_https_clone_url() : $self->obtain_ssh_clone_url();
+  },
+);
+
+has do_clone_via_https => (
+  is => 'ro',
+  default => 0,
 );
 
 has should_fetch_ssh_url_for_forks => (

--- a/lib/App/MintTag/Remote/GitHub.pm
+++ b/lib/App/MintTag/Remote/GitHub.pm
@@ -125,12 +125,18 @@ sub _mr_from_raw ($self, $raw) {
     web_url     => $raw->{html_url},
     is_merged   => !! $raw->{merge_commit_sha},
     branch_name => $raw->{head}->{ref},
-    force_push_url => $raw->{head}->{repo}->{ssh_url},
+    force_push_url => $raw->{head}->{repo}->{clone_url},
     should_delete_branch => 0,  # github is sensible about this, set it there
   });
 }
 
-sub obtain_clone_url ($self) {
+sub obtain_https_clone_url ($self) {
+  my $url = URI->new($self->_raw_repo_data->{clone_url});
+  $url->userinfo($self->api_key);
+  return $url;
+}
+
+sub obtain_ssh_clone_url ($self) {
   return $self->_raw_repo_data->{ssh_url};
 }
 

--- a/lib/App/MintTag/Remote/GitLab.pm
+++ b/lib/App/MintTag/Remote/GitLab.pm
@@ -35,6 +35,15 @@ has my_user_id => (
   },
 );
 
+has my_user_name => (
+  is => 'ro',
+  lazy => 1,
+  default => sub ($self) {
+    my $me = $self->http_get(sprintf("%s/user", $self->api_url));
+    return $me->{username};
+  },
+);
+
 has _fork_ssh_urls => (
   is => 'ro',
   lazy => 1,
@@ -155,7 +164,13 @@ sub ssh_url_for_project_id ($self, $project_id) {
   return $ssh_url;
 }
 
-sub obtain_clone_url ($self) {
+sub obtain_https_clone_url ($self) {
+  my $url = URI->new($self->_raw_repo_data->{http_url_to_repo});
+  $url->userinfo($self->my_user_name . ":" . $self->api_key);
+  return $url;
+}
+
+sub obtain_ssh_clone_url ($self) {
   return $self->_raw_repo_data->{ssh_url_to_repo};
 }
 


### PR DESCRIPTION
Mint-Tag already requires API keys (PAT tokens) for remotes. Both Gitlab and Github support using the identity / permissions from those keys to clone via HTTPS. This simplifies credential management for automated usage of mint-tag - no need for maintaining both API keys *and* SSH keys.

In order to make this work, mint-tag needs to be aware of both clone urls due to how it uses stored clone urls to match up MRs. There is probably another way to do that but this works without a large amount of refactoring.