### PR TITLE
PLAT-1751: Tag pruning

### DIFF
--- a/lib/App/MintTag/BuildStep.pm
+++ b/lib/App/MintTag/BuildStep.pm
@@ -41,6 +41,11 @@ has push_tag_to => (
   is => 'ro',
 );
 
+has cleanup_tag_days => (
+  is => 'ro',
+  default => 0
+);
+
 # Hashref: {
 #   remote => $remote,
 #   force => $bool


### PR DESCRIPTION
This allows mint-tag to prune old tags. We have too many tags and we don't want to add to the fire.

Specifically, this introduces a new `cleanup_tag_days` config option that can be passed for build steps that have `push_tag_to` set and if set to a nonzero number all tags that match the `tag_prefix` and have a commit date older than (roughly) that number of days will be deleted from the remote.