### PR TITLE
when diagnostic merge fails, check multiply-touched files

### DIFF
--- a/lib/App/MintTag/MergeRequest.pm
+++ b/lib/App/MintTag/MergeRequest.pm
@@ -74,6 +74,21 @@ has has_been_rebased_locally => (
   default => 0,
 );
 
+has fetch_affected_files_callback => (
+  is => 'ro',
+  required => 1,
+);
+
+has _affected_files => (
+  is   => 'ro',
+  lazy => 1,
+  default => sub ($self) { $self->fetch_affected_files_callback->($self) }
+);
+
+sub affected_files ($self) {
+  $self->_affected_files->@*;
+}
+
 sub BUILD ($self, $arg) {
   if ( $self->remote->should_fetch_ssh_url_for_forks
     && ! defined $self->force_push_url

--- a/lib/App/MintTag/Remote/GitHub.pm
+++ b/lib/App/MintTag/Remote/GitHub.pm
@@ -127,6 +127,12 @@ sub _mr_from_raw ($self, $raw) {
     branch_name => $raw->{head}->{ref},
     force_push_url => $raw->{head}->{repo}->{clone_url},
     should_delete_branch => 0,  # github is sensible about this, set it there
+    fetch_affected_files_callback => sub ($mr) {
+      my $remote = $mr->remote;
+      my $uri = $remote->uri_for("/pulls/" . $mr->number . "/files");
+      my $res = $mr->remote->http_get($uri);
+      return [ map {; $_->{filename} } @$res ];
+    },
   });
 }
 

--- a/lib/App/MintTag/Remote/GitLab.pm
+++ b/lib/App/MintTag/Remote/GitLab.pm
@@ -136,6 +136,12 @@ sub _mr_from_raw ($self, $raw) {
     is_merged   => $raw->{state} eq 'merged',
     force_push_url => $force_push_url,
     should_delete_branch => $raw->{force_remove_source_branch},
+    fetch_affected_files_callback => sub ($mr) {
+      my $remote = $mr->remote;
+      my $uri = $remote->uri_for("/merge_requests/" . $mr->number . "/diffs");
+      my $res = $mr->remote->http_get($uri);
+      return [ uniq map {; $_->{old_path}, $_->{new_path} } @$res ];
+    },
   });
 }
 


### PR DESCRIPTION
Sometimes, two MRs can be merged A-into-B, but not A-with-B as part of the octopus.  When this happens, we have previously just sort of given up.  This change is just a little better: it shows all files that are touched by more than one MR in the set.