### PR TITLE
avoid ambiguous scalar/list call

### DIFF
--- a/lib/App/MintTag/Artifact.pm
+++ b/lib/App/MintTag/Artifact.pm
@@ -140,7 +140,7 @@ has merge_requests => (
           %$mr,
           key       => $key,
           step_name => $step->{name},
-          remote    => $self->config->remote_for_url($step->{remote}),
+          remote    => scalar $self->config->remote_for_url($step->{remote}),
         },
       }
     }

--- a/lib/App/MintTag/Config.pm
+++ b/lib/App/MintTag/Config.pm
@@ -144,7 +144,7 @@ sub remote_for_url ($self, $clone_url) {
   return $remote if $remote;
 
   # Not dying here, I think.
-  return;
+  return undef;
 }
 
 # In release mode, we do things a little differently


### PR DESCRIPTION
This code was doing the old (key => function()) thing, where the function is called in list context, and might return a number of elements that is not 1.

First, use "scalar".

Second, make the function always return 1 element anyway.