### PR TITLE
Artifact: when producing TOML, exclude credentials

### DIFF
--- a/lib/App/MintTag/Artifact.pm
+++ b/lib/App/MintTag/Artifact.pm
@@ -7,6 +7,7 @@ use experimental qw(postderef signatures);
 
 use TOML::Parser;
 use Try::Tiny;
+use URI;
 
 use App::MintTag::Logger '$Logger';
 
@@ -83,7 +84,13 @@ sub as_toml ($self) {
   for my $step ($self->step_data->@*) {
     push @lines, '[[build_steps]]';
     push @lines, sprintf('name = "%s"', $step->{name});
-    push @lines, sprintf('remote = "%s"', $step->{remote});
+
+    my $remote_uri = URI->new($step->{remote});
+    if ($remote_uri->can('userinfo')) {
+      $remote_uri->userinfo(undef);
+    }
+
+    push @lines, sprintf('remote = "%s"', "$remote_uri");
 
     for my $mr ($step->{merge_requests}->@*) {
       my $title = $mr->{title};


### PR DESCRIPTION
A remote might be user@host.tld:xyz or might be
https://[user:pw]@host.tld/xyz generally speaking.  In the first case, it's ssh and the credentials are sorted out by ssh.  In the second case, it's HTTPS and the credentials are either prompted for or implicit in the URL.  Doing "Credentials in URL" is weird-ish, but makes sense for some automated processes.  Although a more thorough audit of behavior is probably a good idea, this will stop us writing authentication tokens into tags ASAP.

(Good news: we never publish these tags anyway.)